### PR TITLE
Fixed bower dependencies so that node-uuid is a standard dependency instead of dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _Direct client-side UUID generation that exposes [node-uuid](https://github.com/
 
 Original credit for this addon's approach is due to [ember-cli-uuid](https://github.com/thaume/ember-cli-uuid). `ember-simple-uuid` wraps the same function -- but without any dependency on `ember-data` or initializer decoration of `DS.Adapter`. Those wanting such extra behavior may well want to give `ember-cli-uuid` a look.
 
-`ember-simple-uuid` also applies gathers any arguments passed to its function and spreads them to fit the `uuid.v4` signature as documented [here](https://github.com/broofa/node-uuid#uuidv4options--buffer--offset)
+`ember-simple-uuid` also gathers any arguments passed to its function and spreads them to fit the `uuid.v4` function signature. This enables the configuration options documented [here](https://github.com/broofa/node-uuid#uuidv4options--buffer--offset).
 
 
 ## Usage

--- a/bower.json
+++ b/bower.json
@@ -4,9 +4,7 @@
     "ember": "~2.3.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
-  },
-  "devDependencies": {
+    "ember-qunit-notifications": "0.1.0",
     "node-uuid": "^1.4.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-simple-uuid",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Direct client-side UUID generation",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "ember uuid",
     "unique id",
     "ember unique id",
-    "ember node uuid"
+    "ember node uuid",
+    "client unique id",
+    "ember client uuid"
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5"


### PR DESCRIPTION
Fixed bower dependencies so that node-uuid is a standard dependency instead of dev.
